### PR TITLE
Use JSBN as an NPM module

### DIFF
--- a/lib/ec.js
+++ b/lib/ec.js
@@ -3,7 +3,7 @@
 // Only Fp curves implemented for now
 
 // Requires jsbn.js and jsbn2.js
-var BigInteger = require('jsbn')
+var BigInteger = require('jsbn').BigInteger
 var Barrett = BigInteger.prototype.Barrett
 
 // ----------------

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": {
-    "jsbn": "git+https://github.com/rynomad/jsbn.git"
+    "jsbn": "~0.1.0"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Removes dependency on the `git` program during installation.
Allows for semantic versioning.

@quartzjer