### PR TITLE
Use Buffer.from instead of deprecated Buffer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var crypto = require("crypto");
 var BigInteger = require("jsbn").BigInteger;
 var ECPointFp = require("./lib/ec.js").ECPointFp;
+var Buffer = require("safer-buffer").Buffer;
 exports.ECCurves = require("./lib/sec.js");
 
 // zero prepad
@@ -40,17 +41,17 @@ exports.ECKey = function(curve, key, isPublic)
   if(this.P)
   {
 //  var pubhex = unstupid(this.P.getX().toBigInteger().toString(16),bytes*2)+unstupid(this.P.getY().toBigInteger().toString(16),bytes*2);
-//  this.PublicKey = new Buffer("04"+pubhex,"hex");
-    this.PublicKey = new Buffer(c.getCurve().encodeCompressedPointHex(this.P),"hex");
+//  this.PublicKey = Buffer.from("04"+pubhex,"hex");
+    this.PublicKey = Buffer.from(c.getCurve().encodeCompressedPointHex(this.P),"hex");
   }
   if(priv)
   {
-    this.PrivateKey = new Buffer(unstupid(priv.toString(16),bytes*2),"hex");
+    this.PrivateKey = Buffer.from(unstupid(priv.toString(16),bytes*2),"hex");
     this.deriveSharedSecret = function(key)
     {
       if(!key || !key.P) return false;
       var S = key.P.multiply(priv);
-      return new Buffer(unstupid(S.getX().toBigInteger().toString(16),bytes*2),"hex");
+      return Buffer.from(unstupid(S.getX().toBigInteger().toString(16),bytes*2),"hex");
    }     
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     }
   ],
   "dependencies": {
-    "jsbn": "~0.1.0"
+    "jsbn": "~0.1.0",
+    "safer-buffer": "^2.1.0"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This also includes a dependnecy on a polyfill targeting older Node.js versions where Buffer.alloc() and Buffer.from() API is not implemented (Node.js < 4.5.0 and some 5.x versions).

Fixes: https://github.com/quartzjer/ecc-jsbn/issues/5

Ref: https://github.com/nodejs/node/issues/19079
Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Ref: https://nodejs.org/api/buffer.html#buffer_class_buffer
Ref: https://github.com/ChALkeR/safer-buffer/blob/master/Porting-Buffer.md

Alternatively to a dependency, `Buffer.from` polyfill could be bundled inside this package, but I decided not to do that given that Buffer API is used in several places, not one.

Also, I would suggest to use this the polyfill on 0.1.x branch (so that existing users would receive the fix), but also to release a new 0.2.0 version, dropping `safer-buffer` dependency and outdated Node.js <4.5.0 (or even <6.0.0) support.